### PR TITLE
Fix: Overlapping images on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -359,7 +359,7 @@
             </header>
 
             <div class="row">
-                <div class="col-4 col-4-normal col-4-narrower">
+                <div class="col-4 col-4-normal col-12-narrower">
                     <section class="team">
                         <a href="https://www.linkedin.com/in/dor-lasri-ab6703160/" target="_blank">
                             <img class="team-image" src="images/staff/dor.jpg" alt="Dor Lasri"/>
@@ -371,7 +371,7 @@
                     </section>
 
                 </div>
-                <div class="col-4 col-4-normal col-4-narrower">
+                <div class="col-4 col-4-normal col-12-narrower">
 
                     <section class="team">
                         <a href="https://www.linkedin.com/in/nadav-suliman/" target="_blank">
@@ -384,7 +384,7 @@
                     </section>
 
                 </div>
-                <div class="col-4 col-4-normal col-4-narrower">
+                <div class="col-4 col-4-normal col-12-narrower">
                     <section class="team">
                         <a href="https://www.linkedin.com/in/michael-kosoy/" target="_blank">
                             <img class="team-image" src="images/staff/michael.jpg" alt="Michael Kosoy"/>
@@ -405,7 +405,7 @@
                 <h2>Previous <strong>MTA Hacks</strong></h2>
             </header>
             <div class="row">
-                <div class="col-6 col-6-normal col-6-narrower">
+                <div class="col-6 col-6-normal col-12-narrower">
                     <section class="previous">
                         <a href="/2019" target="_top">
                             <img class="previous-hack-image" src="images/logos/hacks/2019.png" alt="MTA Hack 2019"/>
@@ -416,7 +416,7 @@
                     </section>
                 </div>
 
-                <div class="col-6 col-6-normal col-6-narrower">
+                <div class="col-6 col-6-normal col-12-narrower">
                     <section class="previous">
                         <a href="/2017" target="_top">
                             <img class="previous-hack-image" src="images/logos/hacks/2017.png" alt="MTA Hack 2017"/>


### PR DESCRIPTION
'Previous hacks' and 'Team' sections had overlapping bubbles on mobile.