### PR TITLE
 Added CSS classes for different sponsor packages 

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -224,29 +224,28 @@ h3 a {
 }
 
 .platinum img {
-  max-width: 500px;
+  max-width: 475px;
+  padding-bottom: 50px;
+}
+
+.gold {
+  padding-bottom: 50px;
+}
+
+.gold img {
+  max-width: 315px;
+}
+
+.silver {
   padding-bottom: 50px;
 }
 
 .silver img {
+  max-width: 210px;
 }
 
 .bronze img {
-  max-width: 180px;
-}
-
-.silver.duda img {
-  height: 180px;
-}
-
-.bronze.aguda img {
-  height: 100px;
-}
-
-.bronze.wix img {
-  height: 30px;
-  margin-top: 20px;
-  max-width: 100%;
+  max-width: 140px;
 }
 
 .partner img {
@@ -256,11 +255,6 @@ h3 a {
 
 .partner.hamakor img {
   height: 80px;
-}
-
-.gold img {
-  max-width: 350px;
-  padding-bottom: 50px;
 }
 
 .img-link img:hover {

--- a/index.html
+++ b/index.html
@@ -213,10 +213,6 @@
                     </section>
                 </div>
             </div>
-
-            <div class="row bronze">
-                
-            </div> 
         </section>
 
         <!-- Judges -->

--- a/index.html
+++ b/index.html
@@ -196,14 +196,27 @@
             <header class="major">
                 <h2>Our awesome <strong>sponsors</strong></h2>
             </header>
-
-            <div class="row">
-                <div class="col-12 col-12-narrower">
+            <div class="row silver">
+                <div class="col-4 col-6-narrower">
                     <section>
-                        <a href="https://www.duda.co/" class="img-link silver duda" target="_blank"><img src="images/logos/sponsors/duda.svg" alt="Duda" /></a>
+                        <a href="https://www.aguda.mta.ac.il/" class="img-link aguda" target="_blank"><img src="images/logos/sponsors/aguda.png" alt="MTA Aguda" /></a>
+                    </section>
+                </div>
+                <div class="col-4 col-6-narrower">
+                    <section>
+                        <a href="https://www.duda.co/" class="img-link duda" target="_blank"><img src="images/logos/sponsors/duda.svg" alt="Duda" /></a>
+                    </section>
+                </div>
+                <div class="col-4 col-6-narrower">
+                    <section>
+                        <a href="https://www.mta.ac.il/" class="img-link mta" target="_blank"><img src="images/logos/sponsors/mta.jpg" alt="Academic College of Tel Aviv Yaffo" /></a>
                     </section>
                 </div>
             </div>
+
+            <div class="row bronze">
+                
+            </div> 
         </section>
 
         <!-- Judges -->


### PR DESCRIPTION
Added 4 CSS classes for the sponsors sections. One for each sponsor package.
Allows to easily add sponsor logos based on the package they took.

Also added MTA and Aguda as silver sponsors.