### PR TITLE
Updating sponsors' logo size

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -233,7 +233,7 @@ h3 a {
 }
 
 .gold img {
-  max-width: 650px;
+  max-width: 350px;
 }
 
 .silver {
@@ -241,11 +241,11 @@ h3 a {
 }
 
 .silver img {
-  max-width: 210px;
+  max-width: 170px;
 }
 
 .bronze img {
-  max-width: 140px;
+  max-width: 130px;
 }
 
 .partner img {

--- a/index.html
+++ b/index.html
@@ -207,7 +207,7 @@
              <div class="row gold">
                 <div class="col-12 col-12-narrower">
                     <section>
-                        <a href="https://www.wix.engineering/" class="img-link wix" target="_blank"><img src="images/logos/sponsors/wix-eng2.jpg" alt="Wix Engineering" width="650" height="80"/></a>
+                        <a href="https://www.wix.engineering/" class="img-link wix" target="_blank"><img src="images/logos/sponsors/wix-eng2.jpg" alt="Wix Engineering"/></a>
                     </section>
                 </div>
             </div>


### PR DESCRIPTION
Fixed Wix Engineering's ratio, it was a bit stretched before.
Made silver and gold logos a bit smaller.